### PR TITLE
powsybl.com to powsybl.org ; from futur to present

### DIFF
--- a/pages/about.md
+++ b/pages/about.md
@@ -6,7 +6,7 @@ feature-img: "assets/img/Hans_Otto_Theater_Potsdam_-_fake_colors_cut.jpg"
 tags: [Edito]
 ---
 
-FARAO is a [PowSyBl](http://www.powsybl.com) based toolbox that provides software solutions for power systems coordinated capacity calculation and security analysis projects. It will be open sourced on GitHub soon under the [Mozilla Public License 2.0](https://www.mozilla.org/en-US/MPL/2.0/).
+FARAO is a [PowSyBl](http://www.powsybl.org) based toolbox that provides software solutions for power systems coordinated capacity calculation and security analysis projects. It has been open sourced on GitHub under the [Mozilla Public License 2.0](https://www.mozilla.org/en-US/MPL/2.0/).
 
 This website is dedicated to sharing information and news about FARAO project, and other community contributions around FARAO toolbox and powsybl framework.
 


### PR DESCRIPTION
Change the URL philosophy ; Farao won't be open sourced, it's done today.